### PR TITLE
Remove MacOS and Windows from Actions' platforms

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Windows fail to compile now and this platform never was a
priority. MacOS jobs just get canceled for some reason. As we don't
have any users on these platforms we just delete tests on them. May
return it when there are testers.